### PR TITLE
Make secret_shares & secret_threshold optional

### DIFF
--- a/internal/provider/resource_init.go
+++ b/internal/provider/resource_init.go
@@ -43,12 +43,12 @@ func resourceInit() *schema.Resource {
 			argSecretShares: {
 				Description: "Specifies the number of shares to split the master key into.",
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
 			},
 			argSecretThreshold: {
 				Description: "Specifies the number of shares required to reconstruct the master key.",
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
 			},
 			argRecoveryShares: {
 				Description: "Specifies the number of shares to split the recovery key into.",


### PR DESCRIPTION
When vault is configured to use a cloud key, such as aws kms, these values are not required.

Currently, the following error is produced
```
parameters secret_shares,secret_threshold not applicable to seal type awskms
```