### PR TITLE
docs: fix version being referenced in the provider stanza

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ This Provider gives access to the `vault operator` operations, although currentl
 terraform {
   required_providers {
     vaultoperator = {
-      version = "0.2.0"
+      version = "0.1.8"
       source  = "rickardgranberg/vaultoperator"
     }
   }


### PR DESCRIPTION
0.2.0 doesn't exist. Keeping the docs consistent with the latest version would be helpful for folks who just copy/paste the example