### PR TITLE
Add vault_skip_verify attribute to provider configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ provider "vaultoperator" {
 - `kube_config` (Block List) (see [below for nested schema](#nestedblock--kube_config))
 - `request_headers` (Map of String)
 - `vault_addr` (String) Vault instance URL
+- `vault_skip_verify` (Boolean) Disable TLS certificate verification
 - `vault_url` (String, Deprecated) Vault instance URL
 
 <a id="nestedblock--kube_config"></a>

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -17,7 +17,7 @@ data "%[2]s" "test" {
 `, provider, resInit)
 
 func TestAccDataSourceInit(t *testing.T) {
-	startVault(t)
+	startVault(t, false)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccDataSourceInit(t *testing.T) {
 }
 
 func TestAccDataSourceInitComplete(t *testing.T) {
-	startVault(t)
+	startVault(t, false)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -132,7 +132,7 @@ func startVault(t *testing.T, enableTLS bool) {
 
 	for scanner.Scan() {
 		if match := clusterAddress.FindStringSubmatch(scanner.Text()); match != nil {
-			clusterHost, clusterPort, err := net.SplitHostPort(match[1])
+			_, clusterPort, err := net.SplitHostPort(match[1])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -142,7 +142,7 @@ func startVault(t *testing.T, enableTLS bool) {
 				t.Fatal(err)
 			}
 
-			t.Setenv("VAULT_ADDR", fmt.Sprintf("%s://%s:%d", protocol, clusterHost, port-1))
+			t.Setenv("VAULT_ADDR", fmt.Sprintf("%s://localhost:%d", protocol, port-1))
 		}
 
 		if vaultStarted.MatchString(scanner.Text()) {

--- a/internal/provider/helpers_test.go
+++ b/internal/provider/helpers_test.go
@@ -3,20 +3,110 @@ package provider
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"testing"
+	"text/template"
+	"time"
 )
 
-func startVault(t *testing.T) {
+func startVault(t *testing.T, enableTLS bool) {
 	t.Helper()
 
-	configPath, err := filepath.Abs("../../vault.hcl")
+	tempDir, err := os.MkdirTemp("", "vaultoperator-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	keyPath := filepath.Join(tempDir, "key")
+	certPath := filepath.Join(tempDir, "cert")
+	configPath := filepath.Join(tempDir, "vault.hcl")
+	disableTLS := "1"
+	protocol := "http"
+
+	if enableTLS {
+		disableTLS = "0"
+		protocol = "https"
+
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keyFile, err := os.Create(keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer keyFile.Close()
+
+		err = pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		certTemplate := x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "localhost"},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().AddDate(1, 0, 0),
+			KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			BasicConstraintsValid: true,
+			IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		}
+
+		certBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, &key.PublicKey, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		certFile, err := os.Create(certPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer certFile.Close()
+
+		err = pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	configTemplate, err := template.ParseFiles("../../vault.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := struct {
+		CertFile   string
+		KeyFile    string
+		DisableTLS string
+	}{
+		CertFile:   certPath,
+		KeyFile:    keyPath,
+		DisableTLS: disableTLS,
+	}
+
+	configFile, err := os.Create(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer configFile.Close()
+
+	err = configTemplate.Execute(configFile, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +142,7 @@ func startVault(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			t.Setenv("VAULT_ADDR", fmt.Sprintf("http://%s:%d", clusterHost, port-1))
+			t.Setenv("VAULT_ADDR", fmt.Sprintf("%s://%s:%d", protocol, clusterHost, port-1))
 		}
 
 		if vaultStarted.MatchString(scanner.Text()) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -61,6 +61,46 @@ func TestProvider_configure_url_env(t *testing.T) {
 	}
 }
 
+func TestProvider_configure_skip_verify(t *testing.T) {
+	ctx := context.TODO()
+
+	rc := terraform.NewResourceConfigRaw(map[string]interface{}{argVaultUrl: "https://localhost:8200", argVaultSkipVerify: true})
+	p := New("dev")()
+	diags := p.Configure(ctx, rc)
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+}
+func TestProvider_configure_skip_verify_env(t *testing.T) {
+	ctx := context.TODO()
+	addr, addrExists := os.LookupEnv(envVaultAddr)
+	skipVerify, skipVerifyExists := os.LookupEnv(envVaultSkipVerify)
+	resetEnv := func() {
+		if addrExists {
+			os.Setenv(envVaultAddr, addr)
+		} else {
+			os.Unsetenv(envVaultAddr)
+		}
+
+		if skipVerifyExists {
+			os.Setenv(envVaultSkipVerify, skipVerify)
+		} else {
+			os.Unsetenv(envVaultSkipVerify)
+		}
+	}
+	defer resetEnv()
+
+	os.Setenv(envVaultAddr, "https://localhost:8200")
+	os.Setenv(envVaultSkipVerify, "true")
+
+	rc := terraform.NewResourceConfigRaw(map[string]interface{}{})
+	p := New("dev")()
+	diags := p.Configure(ctx, rc)
+	if diags.HasError() {
+		t.Fatal(diags)
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	// You can add code here to run prior to any test case execution, for example assertions
 	// about the appropriate environment variables being set are common to see in a pre-check

--- a/internal/provider/resource_init_test.go
+++ b/internal/provider/resource_init_test.go
@@ -13,6 +13,7 @@ import (
 var testAccResourceInitVar = fmt.Sprintf("%[1]s.test", resInit)
 var testAccResourceInit = fmt.Sprintf(`
 provider "%[1]s" {
+    vault_skip_verify = true
 }
 
 resource "%[2]s" "test" {
@@ -22,7 +23,7 @@ resource "%[2]s" "test" {
 `, provider, resInit)
 
 func TestAccResourceInit(t *testing.T) {
-	startVault(t, false)
+	startVault(t, true)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/internal/provider/resource_init_test.go
+++ b/internal/provider/resource_init_test.go
@@ -22,7 +22,7 @@ resource "%[2]s" "test" {
 `, provider, resInit)
 
 func TestAccResourceInit(t *testing.T) {
-	startVault(t)
+	startVault(t, false)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -115,7 +115,7 @@ resource "%[2]s" "test" {
 		publicKeys[5],
 	)
 
-	startVault(t)
+	startVault(t, false)
 
 	resource.UnitTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/vault.hcl
+++ b/vault.hcl
@@ -1,8 +1,10 @@
 disable_mlock = true
 
 listener "tcp" {
-    tls_disable = 1
     address = "[::]:0"
+    tls_disable = "{{ .DisableTLS }}"
+    tls_cert_file = "{{ .CertFile }}"
+    tls_key_file = "{{ .KeyFile }}"
 }
 
 storage "inmem" {}


### PR DESCRIPTION
Implements #13 by adding a `vault_skip_verify` attribute to the provider configuration, avoiding the need for setting the `VAULT_SKIP_VERIFY` environment variable outside of Terraform, as well as integration tests for this functionality.